### PR TITLE
Concatenate core fix

### DIFF
--- a/panaroo/generate_output.py
+++ b/panaroo/generate_output.py
@@ -222,14 +222,11 @@ def concatenate_core_genome_alignments(core_names, output_dir):
     alignments_dir = output_dir + "/aligned_gene_sequences/"
     #Open up each alignment that is assosciated with a core node
     alignment_filenames = os.listdir(alignments_dir)
-    print("len(alignment_filesnames) %s" %len(alignment_filenames))
     core_filenames = [
         x for x in alignment_filenames if x.split('.')[0] in core_names
     ]
-    print("len(core_filesnames) %s" %len(core_filenames))
     #Read in all these alginemnts
     gene_alignments = []
-    gene_names = []
     isolates = set()
     for filename in core_filenames:
         gene_name = os.path.splitext(os.path.basename(filename))[0]
@@ -241,9 +238,6 @@ def concatenate_core_genome_alignments(core_names, output_dir):
             gene_length = len(record.seq)
             isolates.add(genome_id)
         gene_alignments.append((gene_name, gene_dict, gene_length))
-    print("len(gene_alignments) %s" %len(gene_alignments))
-    print("len(gene_names) %s" %len(gene_names))
-    print("len(isolates) %s" %len(isolates))
     #Combine them
     isolate_aln = []
     for iso in isolates:
@@ -256,7 +250,6 @@ def concatenate_core_genome_alignments(core_names, output_dir):
         isolate_aln.append(SeqRecord(seq, id=iso, description=""))
 
     #Write out the two output files
-    print(isolate_aln)
     SeqIO.write(isolate_aln, output_dir + 'core_gene_alignment.aln', 'fasta')
 
     write_alignment_header(gene_alignments, output_dir)


### PR DESCRIPTION
Fixed a bug where it didn't output a core genome when the entire pan-genome was aligned.