### PR TITLE
Filename length fix

### DIFF
--- a/panaroo/generate_alignments.py
+++ b/panaroo/generate_alignments.py
@@ -29,6 +29,9 @@ def output_sequence(node, isolate_list, temp_directory, outdir):
     output_sequences = (x for x in output_sequences)
     #set filename to gene name
     outname = temp_directory + node["name"] + ".fasta"
+    #check to see if filename is too long
+    if len(outname) >= 248:
+        outname = outname[:248] + ".fasta"
     #Write them to disk
     SeqIO.write(output_sequences, outname, 'fasta')
     return outname


### PR DESCRIPTION
Simple fix to address issue of gene names with filenames longer than the default OS limit in most Unix based systems.