### PR TITLE
Add in changes that Ouli identified

### DIFF
--- a/panaroo/post_run_gff_output.py
+++ b/panaroo/post_run_gff_output.py
@@ -243,7 +243,7 @@ def create_new_gffs(isolate_index, parsed_gffs, pp_isolate_genes,
                 new_gff_body_lines.append(new_gene_line)
 
     # Sort the annotation body of the gff file based on the first coordinate
-    new_gff_body_lines[1:] = sorted(new_gff_body_lines[1:], key = lambda x: int(x.split('\t')[3]))
+    new_gff_body_lines[1:] = sorted(new_gff_body_lines[1:], key = lambda x: (x.split('\t')[0], int(x.split('\t')[3])))
                 
     if gff_format == "prokka":
         new_gff_body_lines.append("##FASTA")


### PR DESCRIPTION
Suggestions for changes identified for non CDS types, and isolate names matching substrings.

1 - Line 82:84 - The previous use if `in` to identify an isolate id/name in a path risked substring matching. We experienced the isolate 7068_6_1 being matched to isolate 1068_6_10. This resulted in 1068_6_10 being passed twice and 7068_6_1 not being passed at all, killing the script later on.
The new solution isolates the isolate id/names (82:83) and then matches the id/name exactly and returns the path (84)

1 - Line 111 - We found that the Type: `repeat_region` (used for CRISR repeats), was passed but did not contain an `ID` causing the script to crash downstream. Line 111 makes sure that only `CDS` types are passed.