### PR TITLE
Devel

### DIFF
--- a/panaroo/generate_alignments.py
+++ b/panaroo/generate_alignments.py
@@ -144,10 +144,10 @@ def output_dna_and_protein(node, isolate_list, temp_directory, outdir,
     if isolate_no > 1:
         #set filename to gene name
         prot_outname = temp_directory + node["name"] + ".fasta"
-        if len(prot_outname) > 248:
+        if len(prot_outname) >= 248:
             prot_outname = prot_outname[:248] + '.fasta'
         dna_outname = outdir + "unaligned_dna_sequences/" + node["name"] + ".fasta"
-        if len(dna_outname) > 248:
+        if len(dna_outname) >= 248:
             dna_outname = dna_outname[:248] + '.fasta'
         #Write them to disk time
         SeqIO.write(output_protein, prot_outname, 'fasta')

--- a/panaroo/post_run_alignment_gen.py
+++ b/panaroo/post_run_alignment_gen.py
@@ -109,7 +109,7 @@ def main():
             if iso not in seen:
                 isolate_names_and_nums[num] = iso
                 seen.add(iso)
-    isolate_names = max_num * ["NA"]
+    isolate_names = (max_num + 1) * ["NA"]
     for isolate_num in isolate_names_and_nums:
         isolate_names[isolate_num] = isolate_names_and_nums[isolate_num]
 

--- a/panaroo/post_run_alignment_gen.py
+++ b/panaroo/post_run_alignment_gen.py
@@ -111,7 +111,7 @@ def main():
                 seen.add(iso)
     isolate_names = max_num * ["NA"]
     for isolate_num in isolate_names_and_nums:
-        isoalte_names[isolate_num] = isolate_names_and_nums[isolate_num]
+        isolate_names[isolate_num] = isolate_names_and_nums[isolate_num]
 
     # Load graph
     G = nx.read_gml(args.output_dir + "final_graph.gml")

--- a/panaroo/post_run_alignment_gen.py
+++ b/panaroo/post_run_alignment_gen.py
@@ -96,13 +96,22 @@ def main():
     # Load isolate names
     seen = set()
     isolate_names = []
+    isolate_names_and_nums = {}
+    max_num = 0
     with open(args.output_dir + "gene_data.csv", 'r') as infile:
         next(infile)
         for line in infile:
-            iso = line.split(",")[0]
+            splitline = line.split(",")
+            iso = splitline[0]
+            num = int(splitline[2].split("_")[0])
+            if num > max_num:
+                max_num = num
             if iso not in seen:
-                isolate_names.append(iso)
+                isolate_names_and_nums[num] = iso
                 seen.add(iso)
+    isolate_names = max_num * ["NA"]
+    for isolate_num in isolate_names_and_nums:
+        isoalte_names[isolate_num] = isolate_names_and_nums[isolate_num]
 
     # Load graph
     G = nx.read_gml(args.output_dir + "final_graph.gml")


### PR DESCRIPTION
A couple of fixes: Filename lengths of codon-aligned sequences now below Unix limit, and post-run alignment generates the list of isolate ids and internal panaroo isolate numbers accurately in edge cases (input isolates totally missing from graph, duplicate isolates in merged datasets).  