### PR TITLE
Only use a random subset of genes for generating core aln

### DIFF
--- a/panaroo/__main__.py
+++ b/panaroo/__main__.py
@@ -235,6 +235,11 @@ Does not delete any genes and only performes merge and refinding\
                       help="Core-genome sample threshold (default=0.95)",
                       type=float,
                       default=0.95)
+    core.add_argument("--core_subset",
+                      dest="subset",
+                      help="Subset the core genome to these many random genes (default=all)",
+                      type=int,
+                      default=None)
     core.add_argument("--core_entropy_filter",
                       dest="hc_threshold",
                       help=("Manually set the Block Mapping and Gathering with " +
@@ -512,7 +517,7 @@ def main():
         generate_core_genome_alignment(G, temp_dir, args.output_dir,
                                        args.n_cpu, args.alr, isolate_names,
                                        args.core, args.codons, len(args.input_files),
-                                       args.hc_threshold)
+                                       args.hc_threshold, args.subset)
 
     # remove temporary directory
     shutil.rmtree(temp_dir)

--- a/panaroo/generate_output.py
+++ b/panaroo/generate_output.py
@@ -443,6 +443,7 @@ def generate_core_genome_alignment(
     if len(core_genes) < 1:
         print("No gene clusters were present above the core frequency"
               " threshold! Try adjusting the '--core_threshold' parameter")
+        return
 
     core_gene_names = [G.nodes[x]["name"] for x in core_genes]
 

--- a/panaroo/generate_output.py
+++ b/panaroo/generate_output.py
@@ -440,6 +440,10 @@ def generate_core_genome_alignment(
         None
     # Get core nodes
     core_genes = get_core_gene_nodes(G, threshold, num_isolates)
+    if len(core_genes) < 1:
+        print("No gene clusters were present above the core frequency"
+              " threshold! Try adjusting the '--core_threshold' parameter")
+
     core_gene_names = [G.nodes[x]["name"] for x in core_genes]
 
     if codons == True:

--- a/panaroo/merge_graphs.py
+++ b/panaroo/merge_graphs.py
@@ -254,6 +254,7 @@ def merge_graphs(directories,
                  alr,
                  core,
                  hc_threshold,
+                 subset=None,
                  merge_single=False,
                  depths=[1,2,3],
                  n_cpu=1,
@@ -421,7 +422,7 @@ def merge_graphs(directories,
         if not quiet: print("generating core genome MSAs...")
         generate_core_genome_alignment(G, temp_dir, output_dir, n_cpu, alr,
                                        isolate_names, core, len(isolate_names), 
-                                       hc_threshold)
+                                       hc_thresholdi, subset)
     return
 
 
@@ -523,6 +524,11 @@ def get_options():
                       help="Core-genome sample threshold (default=0.95)",
                       type=float,
                       default=0.95)
+    core.add_argument("--core_subset",
+                      dest="subset",
+                      help="Subset the core genome to these many random genes (default=all)",
+                      type=int,
+                      default=None)
     core.add_argument("--core_entropy_filter",
                       dest="hc_threshold",
                       help=("Manually set the Block Mapping and Gathering with " +

--- a/panaroo/post_run_alignment_gen.py
+++ b/panaroo/post_run_alignment_gen.py
@@ -55,6 +55,11 @@ def get_options():
                       help="Core-genome sample threshold (default=0.95)",
                       type=float,
                       default=0.95)
+    core.add_argument("--core_subset",
+                      dest="subset",
+                      help="Subset the core genome to these many random genes (default=all)",
+                      type=int,
+                      default=None)
     core.add_argument("--core_entropy_filter",
                       dest="hc_threshold",
                       help=("Manually set the Block Mapping and Gathering with " +
@@ -114,7 +119,7 @@ def main():
         generate_core_genome_alignment(G, temp_dir, args.output_dir,
                                        args.n_cpu, args.alr, isolate_names,
                                        args.core, args.codons, len(isolate_names),
-                                       args.hc_threshold)
+                                       args.hc_threshold, args.subset)
 
     # remove temporary directory
     shutil.rmtree(temp_dir)


### PR DESCRIPTION
Added a `--core_subset` argument to every command with which a user can choose to generate a core genome alignment.

When using large datasets the core genome alignment takes a substantial amount of time, but perhaps a reasonable sample would produce the same phylogenetic signal in a fraction of the time

Tested briefly on a toy dataset, opening a PR in case this is a useful new argument!