### PR TITLE
Fix panaroo-integrate args

### DIFF
--- a/panaroo/integrate.py
+++ b/panaroo/integrate.py
@@ -132,6 +132,14 @@ def get_options(
         choices=['prank', 'clustal', 'mafft'],
         default="mafft")
 
+    core.add_argument(
+        "--codons",
+        dest="codons",
+        help=
+        "Generate codon alignments by aligning sequences at the protein level",
+        action='store_true',
+        default=False)
+
     core.add_argument("--core_threshold",
                       dest="core",
                       help="Core-genome sample threshold (default=0.95)",
@@ -298,6 +306,7 @@ def main():
                  min_edge_support_sv=args.min_edge_support_sv,
                  aln=args.aln,
                  alr=args.alr,
+                 codons=args.codons,
                  core=args.core,
                  hc_threshold=args.hc_threshold,
                  merge_single=True,

--- a/panaroo/merge_graphs.py
+++ b/panaroo/merge_graphs.py
@@ -252,6 +252,7 @@ def merge_graphs(directories,
                  min_edge_support_sv,
                  aln,
                  alr,
+                 codons,
                  core,
                  hc_threshold,
                  merge_single=False,
@@ -420,7 +421,7 @@ def merge_graphs(directories,
     elif aln == "core":
         if not quiet: print("generating core genome MSAs...")
         generate_core_genome_alignment(G, temp_dir, output_dir, n_cpu, alr,
-                                       isolate_names, core, len(isolate_names), 
+                                       isolate_names, core, codons, len(isolate_names), 
                                        hc_threshold)
     return
 


### PR DESCRIPTION
The `generate_core_genome_alignment function` was not getting the `codons` argument making it complain.
This PR adds the `codons` argument to the CLI, to then pass it to the above mentionned function.

Tested with the attached data, and the command below it now works :)

```bash

panaroo-integrate \
--alignment core \
--core_threshold 0.95 \
--remove-invalid-genes \
-t 2 \
-d panaroo_results \
-o results_outgroup \
-i GCA_011765585.gff3
```

[panaroo_test.tar.gz](https://github.com/gtonkinhill/panaroo/files/14270255/panaroo_test.tar.gz)
