### PR TITLE
ci: add pip cache in ci to speed up package installation

### DIFF
--- a/.github/workflows/panaroo_test.yml
+++ b/.github/workflows/panaroo_test.yml
@@ -26,6 +26,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+        cache: pip
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
This PR adds a pip cache to the CI job. After succesfully finishing a CI job, the subsequent jobs will reuse the cached dependencies, speeding up package installation.

Ref: https://github.com/actions/setup-python?tab=readme-ov-file#caching-packages-dependencies