### PR TITLE
Handling bad fasta parsing

### DIFF
--- a/panaroo/prokka.py
+++ b/panaroo/prokka.py
@@ -148,7 +148,10 @@ def get_gene_sequences(gff_file_name, file_number, filter_seqs, table):
         raise RuntimeError("Error reading prokka input!")
 
     with StringIO(split[1]) as temp_fasta:
-        sequences = list(SeqIO.parse(temp_fasta, 'fasta'))
+        try:
+            sequences = list(SeqIO.parse(temp_fasta, 'fasta'))
+        except ValueError:
+            sequences = list(SeqIO.parse(temp_fasta, 'fasta-pearson'))
 
     parsed_gff = gff.create_db(clean_gff_string(split[0]),
                                dbfn=":memory:",


### PR DESCRIPTION
**Problem:**
Previously, observing lines in Fasta files prior to the initial ">" was previously seen as comments. This behaviour was depricated from BioPython release 1.85.  This causes an ValueError in reading prokka GFFs, as the fasta is passed with '##FASTA'. Seems to be related to #372 

**Solution**:
Try and except statement excepts the ValueError thrown by BioPython >=1.85 and makes use of format='fasta-pearson' to allow inital Fasta lines, before ">"