### PR TITLE
Add Bakta-to-Prokka GFF converter script — to handle Bakta-annotated GFF3 inputs

### DIFF
--- a/scripts/convert_bakta_to_prokka_gff.py
+++ b/scripts/convert_bakta_to_prokka_gff.py
@@ -1,0 +1,183 @@
+"""Convert a Bakta-annotated GFF3 file to Prokka-style combined GFF+FASTA.
+
+Sibling to ``scripts/convert_refseq_to_prokka_gff.py``. The refseq variant
+cannot parse Bakta output as distributed (e.g. via BakRep) because:
+
+1. Bakta emits banner / annotation comment lines starting with ``# `` (single
+   hash + space) inside the GFF body. ``gffutils`` tolerates ``##`` directives
+   but these single-hash lines must be stripped before parsing.
+2. Bakta emits comment lines between the ``##FASTA`` separator and the first
+   ``>`` header. Biopython's ``SeqIO.parse`` warns/errors on these.
+
+This script is otherwise identical in behaviour to
+``convert_refseq_to_prokka_gff.py``.
+"""
+
+import argparse
+import sys
+from io import StringIO
+
+import gffutils as gff
+from Bio import SeqIO
+
+
+def strip_bakta_gff_comments(gff_string):
+    """Remove Bakta-specific single-hash comment lines and ``##sequence-region``
+    directives. Keeps all other ``##`` directives and feature lines.
+    """
+    kept = []
+    for line in gff_string.splitlines():
+        stripped = line.lstrip()
+        if stripped.startswith("##sequence-region"):
+            continue
+        # Drop single-hash-plus-space comment lines (Bakta banner / annotations)
+        # but preserve ``##`` directives.
+        if stripped.startswith("# "):
+            continue
+        kept.append(line)
+    return "\n".join(kept)
+
+
+def strip_fasta_preamble(fasta_block):
+    """Drop any lines before the first ``>`` header in a FASTA block.
+
+    Bakta inserts comment lines between ``##FASTA`` and the first record
+    header; Biopython does not accept these.
+    """
+    lines = fasta_block.splitlines()
+    start = 0
+    while start < len(lines) and not lines[start].lstrip().startswith(">"):
+        start += 1
+    return "\n".join(lines[start:])
+
+
+def convert(gfffile, outputfile, fastafile, is_ignore_overlapping):
+    # Split file and parse
+    with open(gfffile, "r") as infile:
+        lines = infile.read().replace(",", "")
+
+    if fastafile is None:
+        split = lines.split("##FASTA")
+        if len(split) != 2:
+            print("Problem reading GFF3 file: ", gfffile)
+            raise RuntimeError("Error reading GFF3 input!")
+    else:
+        with open(fastafile, "r") as infile:
+            fasta_lines = infile.read()
+        split = [lines, fasta_lines]
+
+    cleaned_fasta_block = strip_fasta_preamble(split[1])
+    with StringIO(cleaned_fasta_block) as temp_fasta:
+        sequences = list(SeqIO.parse(temp_fasta, "fasta"))
+
+    for seq in sequences:
+        seq.description = ""
+
+    parsed_gff = gff.create_db(
+        strip_bakta_gff_comments(split[0]),
+        dbfn=":memory:",
+        force=True,
+        keep_order=False,
+        merge_strategy="create_unique",
+        sort_attribute_values=True,
+        from_string=True,
+    )
+
+    with open(outputfile, "w") as outfile:
+        # write gff part
+        outfile.write("##gff-version 3\n")
+        for seq in sequences:
+            outfile.write(
+                " ".join(["##sequence-region", seq.id, "1", str(len(seq.seq))]) + "\n"
+            )
+
+        prev_chrom = ""
+        prev_end = -1
+        ids = set()
+        seen = set()
+        seq_order = []
+        for entry in parsed_gff.all_features(
+            featuretype=(), order_by=("seqid", "start")
+        ):
+            entry.chrom = entry.chrom.split()[0]
+            # skip non CDS
+            if "CDS" not in entry.featuretype:
+                continue
+            # skip overlapping CDS if option is set
+            if (
+                entry.chrom == prev_chrom
+                and entry.start < prev_end
+                and is_ignore_overlapping
+            ):
+                continue
+            # skip CDS that don't appear to be complete or have a premature stop codon
+            premature_stop = False
+            for sequence_index in range(len(sequences)):
+                scaffold_id = sequences[sequence_index].id
+                if scaffold_id == entry.seqid:
+                    gene_sequence = sequences[sequence_index].seq[
+                        (entry.start - 1) : entry.stop
+                    ]
+                    if (len(gene_sequence) % 3 > 0) or (len(gene_sequence) < 34):
+                        premature_stop = True
+                        break
+                    if entry.strand == "-":
+                        gene_sequence = gene_sequence.reverse_complement()
+                    if "*" in str(gene_sequence.translate())[:-1]:
+                        premature_stop = True
+                        break
+            if premature_stop:
+                continue
+
+            c = 1
+            while entry.attributes["ID"][0] in ids:
+                entry.attributes["ID"][0] += "." + str(c)
+                c += 1
+            ids.add(entry.attributes["ID"][0])
+            prev_chrom = entry.chrom
+            prev_end = entry.end
+            if entry.chrom not in seen:
+                seq_order.append(entry.chrom)
+                seen.add(entry.chrom)
+            print(entry, file=outfile)
+
+        # write fasta part
+        outfile.write("##FASTA\n")
+        sequences = [seq for x in seq_order for seq in sequences if seq.id == x]
+        if len(sequences) != len(seen):
+            raise RuntimeError("Mismatch between fasta and GFF!")
+        SeqIO.write(sequences, outfile, "fasta")
+
+    return
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Convert a Bakta-annotated GFF3 to Prokka-style combined GFF+FASTA."
+    )
+    parser.add_argument(
+        "-g", "--gff", dest="gff", type=str, required=True, help="input gff file name"
+    )
+    parser.add_argument(
+        "-f",
+        "--fasta",
+        dest="fasta",
+        type=str,
+        default=None,
+        help="input fasta file name (if separate from the GFF)",
+    )
+    parser.add_argument(
+        "-o", "--out", dest="out", type=str, required=True, help="output file name"
+    )
+    parser.add_argument(
+        "--is_ignore_overlapping",
+        action="store_true",
+        help="set to ignore CDS that overlap (that's common in bacteria)",
+    )
+    args = parser.parse_args()
+
+    convert(args.gff, args.out, args.fasta, args.is_ignore_overlapping)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds a new helper script, `scripts/convert_bakta_to_prokka_gff.py`, which
converts a [Bakta](https://github.com/oschwengers/bakta)-annotated GFF3 +
FASTA pair into Panaroo's expected Prokka-style combined GFF+FASTA — the
same output shape that `scripts/convert_refseq_to_prokka_gff.py` already
produces for RefSeq inputs.

The new script is a sibling, not a replacement: identical CLI
(`-g`/`-f`/`-o`/`--is_ignore_overlapping`) and identical output format,
plus two small input-side fixes that the RefSeq variant lacks.

## Motivation

The existing `convert_refseq_to_prokka_gff.py` cannot parse Bakta GFFs as
distributed (e.g. via [BakRep](https://bakrep.computational.bio)) because
of two Bakta-specific quirks:

1. **`# ` comment lines inside the GFF body.** Bakta emits banner /
   annotation lines that start with a single `#` followed by a space.
   `gffutils.create_db()` accepts `##` directives but fails on these.
2. **Comment lines between `##FASTA` and the first `>` header.** Bakta
   inserts annotation lines into the FASTA preamble. Biopython's
   `SeqIO.parse` warns and/or errors on these.

Working around these by pre-processing every input externally (e.g. with
`sed`) is brittle and easy to forget. Putting the fix inside Panaroo's
own conversion script keeps the entry point uniform across annotation
sources.

## Changes

One new file: `scripts/convert_bakta_to_prokka_gff.py`. It is a near-copy
of `convert_refseq_to_prokka_gff.py` with two added helpers, called once
each at the top of `convert()`:

- `strip_bakta_gff_comments(gff_string)` — drops single-`#`-with-space
  lines and `##sequence-region` directives from the GFF body, preserving
  all other `##` directives and feature lines.
- `strip_fasta_preamble(fasta_block)` — skips ahead to the first `>`
  header in the FASTA block.

Argparse, output format, and the rest of `convert()` are unchanged from
the RefSeq variant, so reviewers can diff the two files to see the full
delta.

## Testing

Validated end-to-end on real Bakta input from BakRep (*Klebsiella
pneumoniae*) using a **Full pangenome run** on 30 *K. pneumoniae* genomes

   ```bash
   panaroo -i panaroo_input.txt -o ./out --clean-mode strict \
           --remove-invalid-genes -t 16
   ```

 The `gene_presence_absence.csv` shows appropriate output of pangenome. 