### PR TITLE
Add support for additional MSA Tools

### DIFF
--- a/panaroo/__main__.py
+++ b/panaroo/__main__.py
@@ -572,6 +572,7 @@ def main():
                               alignment="pan",
                               aligner=args.alr,
                               codons=args.codons,
+                              strict_codons=args.strict_codons,
                               core_threshold=args.core,
                               subset=None,
                               resume=False)
@@ -588,6 +589,7 @@ def main():
                               alignment="core",
                               aligner=args.alr,
                               codons=args.codons,
+                              strict_codons=args.strict_codons,
                               core_threshold=args.core,
                               subset=args.subset,
                               resume=False)

--- a/panaroo/generate_alignments.py
+++ b/panaroo/generate_alignments.py
@@ -171,7 +171,7 @@ def check_resume_manifest_collision(output_dir, resume):
     )
 
 
-def write_resume_manifest(output_dir, alignment, aligner, codons,
+def write_resume_manifest(output_dir, alignment, aligner, codons, strict_codons,
                           core_threshold, subset=None, resume=False):
     manifest_path = get_resume_manifest_path(output_dir)
     existing_manifest = load_resume_manifest(output_dir)
@@ -186,6 +186,7 @@ def write_resume_manifest(output_dir, alignment, aligner, codons,
             ("alignment", alignment),
             ("aligner", aligner),
             ("codons", codons),
+            ("strict_codons", strict_codons),
             ("core_threshold", core_threshold),
             ("subset", subset),
         ]:
@@ -202,6 +203,7 @@ def write_resume_manifest(output_dir, alignment, aligner, codons,
         "alignment": alignment,
         "aligner": aligner,
         "codons": codons,
+        "strict_codons": strict_codons,
         "core_threshold": core_threshold,
         "subset": subset,
     }
@@ -685,8 +687,8 @@ def multithread_codonalign_build(protein, dna, name):
     return(name, codon_alignment)
 
 def reverse_translate_sequences(protein_sequence_files, dna_sequence_files, 
-                                outdir, temp_directory, aligner, threads,
-                                completed_alignments_found=0):
+                                strict, outdir, temp_directory, aligner, 
+                                threads, completed_alignments_found=0):
     #Check that the dna and protein files match up
     for index in range(len(protein_sequence_files)):
         gene_id = protein_sequence_files[index].split('/')[-1].split(".")[0]

--- a/panaroo/generate_output.py
+++ b/panaroo/generate_output.py
@@ -254,7 +254,7 @@ def generate_pan_genome_alignment(G, temp_dir, output_dir, threads, aligner,
         resume=resume)
     total_gene_count = len(gene_ids)
 
-    if codons == True:
+    if codons == True or strict == True:
         protein_pending_gene_ids, reverse_translate_pending_gene_ids = (
             get_pending_codon_gene_ids(
                 [(gene_id, G.nodes[gene_id]) for gene_id in gene_ids],

--- a/panaroo/integrate.py
+++ b/panaroo/integrate.py
@@ -144,6 +144,13 @@ def get_options(
         "Generate codon alignments by aligning sequences at the protein level",
         action='store_true',
         default=False)
+    core.add_argument(
+        "--strict-codons",
+        dest="strict_codons",
+        help=
+        "Only generate condon alignments with well-formed protein sequences",
+        action='store_true',
+        default=False),
     core.add_argument("--core_threshold",
                       dest="core",
                       help="Core-genome sample threshold (default=0.95)",
@@ -328,6 +335,7 @@ def main():
                  alr=args.alr,
                  core=args.core,
                  codons=args.codons,
+                 strict_codons=args.strict_codons,
                  hc_threshold=args.hc_threshold,
                  subset=args.subset,
                  merge_single=True,

--- a/panaroo/merge_graphs.py
+++ b/panaroo/merge_graphs.py
@@ -265,6 +265,7 @@ def merge_graphs(directories,
                  alr,
                  core,
                  codons,
+                 strict_codons,
                  hc_threshold,
                  subset=None,
                  merge_single=False,
@@ -440,11 +441,12 @@ def merge_graphs(directories,
                               alignment="pan",
                               aligner=alr,
                               codons=codons,
+                              codons=strict_codons
                               core_threshold=core,
                               subset=None,
                               resume=False)
         generate_pan_genome_alignment(G, temp_dir, output_dir, n_cpu, alr,
-                                      codons, isolate_names)
+                                      codons, strict_codons, isolate_names)
         core_nodes = get_core_gene_nodes(G, core, len(isolate_names))
         concatenate_core_genome_alignments(core_nodes, output_dir, hc_threshold)
     elif aln == "core":
@@ -458,8 +460,8 @@ def merge_graphs(directories,
                               subset=subset,
                               resume=False)
         generate_core_genome_alignment(G, temp_dir, output_dir, n_cpu, alr,
-                                       isolate_names, core, codons, len(isolate_names), 
-                                       hc_threshold, subset)
+                                       isolate_names, core, codons, strict_codons,
+                                       len(isolate_names), hc_threshold, subset)
         
     return
 
@@ -571,6 +573,13 @@ def get_options():
         "Generate codon alignments by aligning sequences at the protein level",
         action='store_true',
         default=False)
+    core.add_argument(
+        "--strict-codons",
+        dest="strict_codons",
+        help=
+        "Only generate condon alignments with well-formed protein sequences",
+        action='store_true',
+        default=False)
     core.add_argument("--core_threshold",
                       dest="core",
                       help="Core-genome sample threshold (default=0.95)",
@@ -651,6 +660,7 @@ def main():
                  alr=args.alr,
                  core=args.core,
                  codons=args.codons,
+                 codons=args.strict_codons,
                  hc_threshold=args.hc_threshold,
                  subset=args.subset,
                  n_cpu=args.n_cpu,

--- a/panaroo/merge_graphs.py
+++ b/panaroo/merge_graphs.py
@@ -660,7 +660,7 @@ def main():
                  alr=args.alr,
                  core=args.core,
                  codons=args.codons,
-                 codons=args.strict_codons,
+                 strict_codons=args.strict_codons,
                  hc_threshold=args.hc_threshold,
                  subset=args.subset,
                  n_cpu=args.n_cpu,

--- a/panaroo/merge_graphs.py
+++ b/panaroo/merge_graphs.py
@@ -441,7 +441,7 @@ def merge_graphs(directories,
                               alignment="pan",
                               aligner=alr,
                               codons=codons,
-                              codons=strict_codons,
+                              strict_codons=strict_codons,
                               core_threshold=core,
                               subset=None,
                               resume=False)

--- a/panaroo/merge_graphs.py
+++ b/panaroo/merge_graphs.py
@@ -441,7 +441,7 @@ def merge_graphs(directories,
                               alignment="pan",
                               aligner=alr,
                               codons=codons,
-                              codons=strict_codons
+                              codons=strict_codons,
                               core_threshold=core,
                               subset=None,
                               resume=False)

--- a/panaroo/post_run_alignment_gen.py
+++ b/panaroo/post_run_alignment_gen.py
@@ -134,6 +134,7 @@ def main():
                               alignment="pan",
                               aligner=args.alr,
                               codons=args.codons,
+                              strict_codons=args.strict_codons,
                               core_threshold=args.core,
                               subset=None,
                               resume=args.resume)
@@ -153,6 +154,7 @@ def main():
                               alignment="core",
                               aligner=args.alr,
                               codons=args.codons,
+                              strict_codons=args.strict_codons,
                               core_threshold=args.core,
                               subset=args.subset,
                               resume=args.resume)


### PR DESCRIPTION
This PR includes changes to add support for MUSCLE and FAMSA multiple sequence aligners, including MUSCLE's super5 mode for larger datasets.

As part of this support, it also adds a sanity check for alignment requests, FAMSA only supports amino acid alignment, and prints a warning when users specify MUSCLE's default alignment mode with more than 300 isolates (as per its documentation). 

It also adds a new flag for alignment, `--strict-codons`, which skips the DNA realignment step in the codon alignment pathway and only outputs well-formed, translatable genes. It also includes a minor bugfix which addresses the discrepancy between the custom (and more accurate) translate method panaroo uses and biopython's default .translate() method in codon alignment (by replacing the latter). 

